### PR TITLE
ci: weekly Dependabot with grouped auto-merge for low-risk updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,100 @@
+# Dependabot configuration.
+#
+# Version updates run weekly and are grouped by concern so a single failing
+# update only blocks its own area. Minor/patch updates are grouped (and
+# auto-merged by .github/workflows/dependabot-auto-merge.yml once CI is green);
+# major updates are intentionally left ungrouped so each opens an individual
+# PR for manual review. Security updates are unaffected by this file and
+# continue to open immediately.
+version: 2
+updates:
+  # npm — the extension's build/test/lint toolchain (all devDependencies).
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 10
+    versioning-strategy: increase
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      # Linting & formatting (ESLint stack, Prettier, gts).
+      linting:
+        patterns:
+          - 'eslint'
+          - '@eslint/*'
+          - 'eslint-*'
+          - 'typescript-eslint'
+          - 'prettier'
+          - 'gts'
+          - 'globals'
+        update-types:
+          - minor
+          - patch
+      # Unit / integration / e2e testing toolchain.
+      testing:
+        patterns:
+          - 'jest'
+          - 'jest-*'
+          - 'ts-jest'
+          - '@playwright/test'
+          - '@types/jest'
+          - 'cheerio'
+        update-types:
+          - minor
+          - patch
+      # Build & bundling (bundler, image pipeline, TS compiler).
+      build:
+        patterns:
+          - 'esbuild'
+          - 'sharp'
+          - 'tslib'
+          - 'typescript'
+        update-types:
+          - minor
+          - patch
+      # Repo tooling (git hooks, commit lint, dead-code & dependency analysis).
+      tooling:
+        patterns:
+          - 'husky'
+          - 'lint-staged'
+          - '@commitlint/*'
+          - 'knip'
+          - 'dependency-cruiser'
+        update-types:
+          - minor
+          - patch
+      # Remaining type definitions (@types/chrome, @types/node, ...).
+      types:
+        patterns:
+          - '@types/*'
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used by the CI / release / publish workflows.
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+      timezone: Etc/UTC
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: ci
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+name: Dependabot auto-merge
+
+# Enables GitHub's native auto-merge on Dependabot PRs for low-risk updates.
+# Auto-merge only completes once all required status checks (pr-validate) pass,
+# so a failing update is never merged. Major version bumps are left for manual
+# review.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # For grouped PRs the update-type reflects the highest semver bump in the
+      # group; groups are capped at minor, so majors never reach this branch.
+      - name: Enable auto-merge for patch & minor updates
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Sets up automated weekly dependency maintenance.

### `.github/dependabot.yml`
- **Weekly** version updates (Mondays 06:00 UTC) for **npm** and **github-actions**.
- **Concern-based grouping** of minor/patch updates so a failing update only blocks its own area:
  - `linting` — ESLint stack, Prettier, gts
  - `testing` — Jest, ts-jest, Playwright, cheerio
  - `build` — esbuild, sharp, tslib, typescript
  - `tooling` — husky, lint-staged, commitlint, knip, dependency-cruiser
  - `types` — remaining `@types/*`
  - `github-actions` — all actions
- **Major** version updates are intentionally left ungrouped → each opens an individual PR for manual review.
- Security updates are unaffected and continue to open immediately.

### `.github/workflows/dependabot-auto-merge.yml`
- Enables GitHub native **auto-merge** on Dependabot **patch & minor** PRs (and minor GitHub Actions bumps).
- Auto-merge completes **only after the required `pr-validate` check passes**, so a failing update is never merged.
- Majors are excluded (left for manual review).

## Required: branch ruleset
For auto-merge to wait on CI, the `main` ruleset now requires the `pr-validate` status check. (Applied separately to the repo ruleset.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)