### PR TITLE
fix(ci): use existing github_actions label in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -88,7 +88,7 @@ updates:
       timezone: Etc/UTC
     labels:
       - dependencies
-      - github-actions
+      - github_actions
     commit-message:
       prefix: ci
     groups:


### PR DESCRIPTION
Dependabot reported: *"The following labels could not be found: github-actions."*

Dependabot requires labels to pre-exist and won't create them. The repo already has the **`github_actions`** label (underscore — the Dependabot convention); the config referenced **`github-actions`** (hyphen), which doesn't exist.

Switches the github-actions ecosystem label to the existing `github_actions`, resolving the config error without creating a redundant duplicate label.

Note: this is a `dependabot.yml`-only change, which isn't in the `pr-validate` path filter, so that check won't run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)