### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ on:
       - 'eslint.config.mjs'
       - '.github/workflows/**'
 
+permissions:
+  contents: write
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/astiskala/psp-detector/security/code-scanning/36](https://github.com/astiskala/psp-detector/security/code-scanning/36)

Add an explicit `permissions` block to `.github/workflows/release.yml` so token scopes are documented and constrained.  
Best fix here: set workflow-level permissions to:

- `contents: write` (required for creating a GitHub Release and uploading release assets)

Because this workflow’s final step publishes a release, `contents: write` is the minimal practical permission. Place the block near the top level (after `on:` section and before `jobs:`), so it applies to all jobs unless overridden. No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
