### PR TITLE
Potential fix for code scanning alert no. 35: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -16,6 +16,9 @@ on:
       - 'eslint.config.mjs'
       - '.github/workflows/**'
 
+permissions:
+  contents: read
+
 jobs:
   pr-validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/astiskala/psp-detector/security/code-scanning/35](https://github.com/astiskala/psp-detector/security/code-scanning/35)

Add an explicit `permissions` block to `.github/workflows/pr-validate.yml` at the workflow root (best single change), so all jobs inherit least-privilege token scopes unless overridden. For this workflow, `contents: read` is the minimal and appropriate permission for checkout and read-only CI operations.

Change region:
- In `.github/workflows/pr-validate.yml`, insert after the `on:` trigger block (before `jobs:`):
  - `permissions:`
  - `  contents: read`

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
