### PR TITLE
Potential fix for code scanning alert no. 34: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -7,6 +7,9 @@ on:
       - 'tests/**'
       - 'sonar-project.properties'
 
+permissions:
+  contents: read
+
 jobs:
   sonar:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/astiskala/psp-detector/security/code-scanning/34](https://github.com/astiskala/psp-detector/security/code-scanning/34)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is scoped to least privilege.  
Best fix here is at the workflow root (top-level), since there is currently only one job and this applies consistently to all jobs unless overridden later.

**Change to make in `.github/workflows/sonar.yml`:**
- Insert after the `on:` trigger section (before `jobs:`):
  - `permissions:`
  - `contents: read`

No imports, methods, or dependencies are needed (YAML config only). This preserves existing behavior while preventing accidental write-capable token defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
