### PR TITLE
Potential fix for code scanning alert no. 47: Incomplete URL substring sanitization

### DIFF
--- a/src/background.test.ts
+++ b/src/background.test.ts
@@ -1012,7 +1012,14 @@ describe('telemetry privacy boundary', () => {
   function gaCalls(): { url: string; body: string }[] {
     const fetchMock = globalThis.fetch as unknown as jest.Mock;
     return fetchMock.mock.calls
-      .filter((call) => String(call[0]).includes(GA_HOST))
+      .filter((call) => {
+        try {
+          const url = new URL(String(call[0]));
+          return url.hostname === GA_HOST || url.hostname.endsWith(`.${GA_HOST}`);
+        } catch {
+          return false;
+        }
+      })
       .map((call) => ({
         url: String(call[0]),
         // The telemetry client always sends a JSON string body.

--- a/src/background.test.ts
+++ b/src/background.test.ts
@@ -1015,7 +1015,9 @@ describe('telemetry privacy boundary', () => {
       .filter((call) => {
         try {
           const url = new URL(String(call[0]));
-          return url.hostname === GA_HOST || url.hostname.endsWith(`.${GA_HOST}`);
+          return (
+            url.hostname === GA_HOST || url.hostname.endsWith(`.${GA_HOST}`)
+          );
         } catch {
           return false;
         }


### PR DESCRIPTION
Potential fix for [https://github.com/astiskala/psp-detector/security/code-scanning/47](https://github.com/astiskala/psp-detector/security/code-scanning/47)

Use robust URL parsing and compare the parsed hostname against the expected analytics host (optionally allowing subdomains if desired), instead of doing a raw substring check on the full URL string.

Best fix for this file:
- In `src/background.test.ts`, update the `gaCalls()` filter logic around line 1015.
- Convert `call[0]` to a string, parse with `new URL(...)`, and check `parsed.hostname`.
- Keep behavior safe for invalid/non-URL values by catching parse errors and returning `false` in the filter.
- To preserve likely intent (matching GA endpoints and possible subdomains), accept `hostname === GA_HOST` or `hostname.endsWith(\`.${GA_HOST}\`)`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
